### PR TITLE
docs(java-opts): Add JAVA_OPTS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You will need to configure the following environment variables:
   logstash instance
 * `ELASTICSEARCH_URL` the URL of your elasticsearch instance. (If you use our
   Elasticsearch addon, this will be automatically added)
+* `JAVA_OPTS` to set the JVM args to configure memory parameters like -Xms and -Xmx
 
 You will also change the `change-me` index name in the output section of your
 logstash configuration.

--- a/scalingo.json
+++ b/scalingo.json
@@ -18,6 +18,10 @@
     "PASSWORD": {
       "generator": "secret",
       "required": true
+    },
+    "JAVA_OPTS": {
+      "value": "-Xms512m -Xmx1024m",
+      "required": true
     }
   },
   "addons": [


### PR DESCRIPTION
A customer had this problem:
```
2021-09-23 14:19:21.188824517 +0000 UTC [web-1] Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them.
2021-09-23 14:19:21.373859015 +0000 UTC [web-1] Error occurred during initialization of VM
2021-09-23 14:19:21.373871731 +0000 UTC [web-1] Initial heap size set to a larger value than the maximum heap size
```

Maybe we can automate it in the logstash builldpack, but for now it is enough.